### PR TITLE
Add to enable private browsing window for extensions

### DIFF
--- a/policies.json
+++ b/policies.json
@@ -73,12 +73,22 @@
             "MoreFromMozilla": false,
             "FirefoxLabs": true
         },
-        "Extensions": {
-            "Install": [
-                "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi",
-		"https://addons.mozilla.org/firefox/downloads/latest/clearurls/latest.xpi",
-		"http://addons.mozilla.org/firefox/downloads/latest/decentraleyes/latest.xpi"
-            ]
+        "ExtensionSettings": {
+            "uBlock0@raymondhill.net": {
+                "install_url": "https://addons.mozilla.org/firefox/downloads/latest/uBlock0@raymondhill.net/latest.xpi",
+                "installation_mode": "normal_installed",
+                "private_browsing": true
+            },
+            "{74145f27-f039-47ce-a470-a662b129930a}": {
+                "install_url": "https://addons.mozilla.org/firefox/downloads/latest/{74145f27-f039-47ce-a470-a662b129930a}/latest.xpi",
+                "installation_mode": "normal_installed",
+                "private_browsing": true
+            },
+            "jid1-BoFifL9Vbdl2zQ@jetpack": {
+                "install_url": "https://addons.mozilla.org/firefox/downloads/latest/jid1-BoFifL9Vbdl2zQ@jetpack/latest.xpi",
+                "installation_mode": "normal_installed",
+                "private_browsing": true
+            }
         },
         "SearchEngines": {
             "PreventInstalls": false,


### PR DESCRIPTION
Ah, yes. Now I can contribute to your project! *(I don't know if I should pull request in git.sr.ht instead. But, it's an email-based anyway and I don't want myself complicate things more)*

This patch in `policies.json` will make any extension (If `private_browsing` is set to `true`) auto-enables private browsing window. Impressive, right? No more hassle digging through the settings again!

There's a catch, sadly. Using `ExtensionSettings` will make all extensions NOT uninstallable (In my testing). But you can disable any extension (If `normal_installed` is set in `installation_mode`).

And, if you were wondering. What does `jid1-BoFifL9Vbdl2zQ@jetpack` means? Well, it's Decentraleyes extension, as an XPI file in `~/.mozilla/firefox/XXXXXXXX-default.*/extension` folder or in `~/.config/mozilla/firefox/XXXXXXXX-default.*/extension` folder. Sadly, some extensions are gibberish (e.g. {74145f27-f039-47ce-a470-a662b129930a} which is ClearURL extension). You have to manually find a specific extension you want using this link: https://addons.mozilla.org/firefox/downloads/latest/<xpi_filename>/latest.xpi

Ex.

Decentraleyes: https://addons.mozilla.org/firefox/downloads/latest/jid1-BoFifL9Vbdl2zQ@jetpack/latest.xpi
ClearURL: https://addons.mozilla.org/firefox/downloads/latest/{74145f27-f039-47ce-a470-a662b129930a}/latest.xpi

Let me know if you want to make this patch better.

(*I discovered it from LibreWolf's [`policies.json`](https://codeberg.org/librewolf/settings/src/branch/master/distribution/policies.json)*, if you were wondering)